### PR TITLE
Fix npe when quiz times out

### DIFF
--- a/src/main/java/dev/roanoke/trivia/Quiz/QuizManager.java
+++ b/src/main/java/dev/roanoke/trivia/Quiz/QuizManager.java
@@ -199,6 +199,9 @@ public class QuizManager {
     }
 
     public void timeOutQuiz(MinecraftServer server) {
+        if (currentQuestion == null) {
+            return;
+        }
         Map<String, String> placeholders = new HashMap<>();
         placeholders.put("{answer}", String.join(", ", currentQuestion.answers));
 


### PR DESCRIPTION
Fix an npe when the quiz times out but no quiz was actually started

```
[00:34:13] [Server thread/ERROR]: Encountered an unexpected exception
java.lang.NullPointerException: Cannot read field "answers" because "this.currentQuestion" is null
        at knot/dev.roanoke.trivia.Quiz.QuizManager.timeOutQuiz(QuizManager.java:203) ~[Trivia-1.2.5+1.21.1.jar:?]
        at knot/dev.roanoke.trivia.Trivia.lambda$onInitialize$1(Trivia.java:54) ~[Trivia-1.2.5+1.21.1.jar:?]
        at knot/net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents.lambda$static$0(ServerTickEvents.java:34) ~[fabric-lifecycle-events-v1-2.5.0+01d9a51c19-e15e35a191b3f234.jar:?]
        at knot/net.minecraft.server.MinecraftServer.handler$zpd000$fabric-lifecycle-events-v1$onStartTick(MinecraftServer.java:7158) ~[server-intermediary.jar:?]
        at knot/net.minecraft.server.MinecraftServer.method_3748(MinecraftServer.java:912) ~[server-intermediary.jar:?]
        at knot/net.minecraft.server.MinecraftServer.method_29741(MinecraftServer.java:697) ~[server-intermediary.jar:?]
        at knot/net.minecraft.server.MinecraftServer.method_29739(MinecraftServer.java:281) ~[server-intermediary.jar:?]
        at java.base/java.lang.Thread.run(Thread.java:1583) [?:?]
[00:34:13] [Server thread/ERROR]: This crash report has been saved to: /home/container/crash-reports/crash-2025-03-31_00.34.13-server.txt
```